### PR TITLE
Drop "register" keyword since is deprecated

### DIFF
--- a/Source/Terra/LAND.CPP
+++ b/Source/Terra/LAND.CPP
@@ -71,7 +71,7 @@ void vrtMap::landPrepare(void)
 	int max = 0;
 
 	int calc = 1;
-	register int i,j,r,ind;
+	int i,j,r,ind;
 	short* p = rad;
 	if(calc){
 		for(j=-MAX_RADIUS_CIRCLEARR; j<=MAX_RADIUS_CIRCLEARR; j++)
@@ -130,7 +130,7 @@ void vrtMap::deltaZone(sToolzerPMO& var) //(int x,int y,int rad,int smth,int dh,
 
 	static int locp;
 
-	register int i,j;
+	int i,j;
 	int max;
 	int* xx,*yy;
 
@@ -325,7 +325,7 @@ void vrtMap::squareDeltaZone(sSquareToolzerPMO& var)//(int x,int y,int rad,int s
 
 	static int locp;
 
-	register int i,j;
+	int i,j;
 	int max;
 	int* xx,*yy;
 
@@ -638,7 +638,7 @@ void vrtMap::GeoSetZone(int x, int y, int rad, int level, int delta)
 		rad=MAX_RADIUS_CIRCLEARR;
 	}
 
-	register int i,j;
+	int i,j;
 	int max;
 	int* xx,*yy;
 
@@ -711,7 +711,7 @@ int vrtMap::renderBox(int LowX,int LowY,int HiX,int HiY, int changed)//int sizeX
 	}
 
 #else
-	register int j;
+	int j;
 	for(j = 0;j <= sizeY;j++){
 		const int y = YCYCL(j + LowY);
 		if(changed) changedT[y] = 1;
@@ -852,7 +852,7 @@ loc_endRnrCycl:
 	list<sRect>::iterator ra;
 	FOR_EACH(renderAreas,ra){
 		int minX=ra->x;
-		register int j;
+		int j;
 		//for(j = 0; j<= ra->dy; j++){
 		//	const int y = YCYCL(j + ra->y);
 		//	int resultx=RenderStr(ra->x, y, ra->dx);
@@ -899,7 +899,7 @@ void vrtMap::regRender(int LowX,int LowY,int HiX,int HiY,int changed)
 
 //	int BackScanLen = 0;
 /*	int minX=LowX;
-	register int j;
+	int j;
 	for(j = 0;j <= SizeY;j++){
 		const int y = YCYCL(j + LowY);
 		if(changed) changedT[y] = 1;

--- a/Source/Terra/VMAP.CPP
+++ b/Source/Terra/VMAP.CPP
@@ -267,7 +267,7 @@ void ConvertProcedure(char* name)
 	unsigned char* buf = new unsigned char[xsize];
 
 //	cout <<endl;
-	register int i;
+	int i;
 	for(i = 0;i < ysize;i++){
 		fin.read(buf,xsize);
 		fout.write(buf,xsize);
@@ -442,7 +442,7 @@ void vrtMap::prepare(char* name)
 	prmFile.init(name);
 	maxWorld = atoi(prmFile.getAtom());
 	if(maxWorld < 1) ErrH.Abort("Empty world list");
-	register int i;
+	int i;
 	char* atom;
 	char tString[256];
 	wTable = new vrtWorld[maxWorld];
@@ -1599,7 +1599,7 @@ void vrtMap::scaling16(int cx,int cy,int xc,int yc,int xside,int yside, unsigned
 
 //	request(MIN(y0,y1) - MAX_RADIUS/2,MAX(y0,y1) + MAX_RADIUS/2,MIN(x0,x1) - 4,MAX(x0,x1) + 4);
 
-	register int i,j,fx,fy;
+	int i,j,fx,fy;
 	unsigned char* lc = &(RnrBuf[0]);//
 	unsigned char* ls = &(SurBuf[0]);
 
@@ -1737,7 +1737,7 @@ void vrtMap::scaling32(int cx,int cy,int xc,int yc,int xside,int yside, unsigned
 	int y1 = y0 + YSrcSize;
 
 
-	register int i,j,fx,fy;
+	int i,j,fx,fy;
 	unsigned char* lc = &(RnrBuf[0]);//
 	unsigned char* ls = &(SurBuf[0]);
 
@@ -2727,7 +2727,7 @@ void vrtMap::wrldShot(void)
 
 	unsigned char* line = new unsigned char[SX*3],*p;
 
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<V_SIZE; j++){
 		p = line;
 		for(i = 0; i<H_SIZE; i++){
@@ -2790,7 +2790,7 @@ void vrtMap::wrldShotOutLine(void)
 
 	unsigned char* line = new unsigned char[SX*3],*p;
 
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<V_SIZE; j++){
 		p = line;
 		for(i = 0; i<H_SIZE; i++){
@@ -2846,7 +2846,7 @@ void vrtMap::wrldShotMapHeight(void)
 
 	unsigned char* line = new unsigned char[SX],*p;
 
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<V_SIZE; j++){
 		p = line;
 		for(i = 0; i<H_SIZE; i++){
@@ -2888,7 +2888,7 @@ void vrtMap::superWrldShot(int k)
 
 	unsigned char* line = new unsigned char[SX*3],*p;
 
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<V_SIZE; j++){
 		p = line;
 		for(i = 0; i<H_SIZE; i++){
@@ -2931,7 +2931,7 @@ void vrtMap::superWrldShot(int k)
 
 void vrtMap::FlipWorldH(void)
 {
-	register unsigned int i,j;
+	unsigned int i,j;
 	int DY=V_SIZE;
 	int DX=H_SIZE>>1;
 	int MX=H_SIZE-1;
@@ -2950,7 +2950,7 @@ void vrtMap::FlipWorldH(void)
 
 void vrtMap::FlipWorldV(void)
 {
-	register unsigned int i,j;
+	unsigned int i,j;
 	int DY=V_SIZE>>1;
 	int DX=H_SIZE;
 	int MY=V_SIZE-1;
@@ -2969,7 +2969,7 @@ void vrtMap::FlipWorldV(void)
 
 void vrtMap::RotateWorldP90(void)
 {
-	register unsigned int i,j;
+	unsigned int i,j;
 	int DY=V_SIZE>>1;
 	int DX=H_SIZE-1;
 	int BEGI=0;
@@ -3001,7 +3001,7 @@ void vrtMap::RotateWorldP90(void)
 
 void vrtMap::RotateWorldM90(void)
 {
-	register unsigned int i,j;
+	unsigned int i,j;
 	int DY=V_SIZE>>1;
 	int DX=H_SIZE-1;
 	int BEGI=0;
@@ -3238,7 +3238,7 @@ void vrtMap::scalingHeighMap(int percent)
 {
 	float k=(float)percent/100.f;
 	static int cnt = 0;
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<V_SIZE; j++){
 		for(i = 0; i<H_SIZE; i++){
 			int offb=offsetBuf(i,j);

--- a/Source/Terra/geo.cpp
+++ b/Source/Terra/geo.cpp
@@ -183,7 +183,7 @@ const float a90=(float)3.1415/2;
 int dh=1<<VX_FRACTION;
 void geoInfluence(int x,int y)
 {
-	register int i,j;
+	int i,j;
 //	int max;
 //	int* xx,*yy;
 

--- a/Source/Terra/pn.cpp
+++ b/Source/Terra/pn.cpp
@@ -57,7 +57,7 @@ float noise2(float vec[2])
 {
 	int bx0, bx1, by0, by1, b00, b10, b01, b11;
 	float rx0, rx1, ry0, ry1, *q, sx, sy, a, b, t, u, v;
-	register int i, j;
+	int i, j;
 
 	if (start) {
 		start = 0;
@@ -95,7 +95,7 @@ float noise3(float vec[3])
 {
 	int bx0, bx1, by0, by1, bz0, bz1, b00, b10, b01, b11;
 	float rx0, rx1, ry0, ry1, rz0, rz1, *q, sy, sz, a, b, c, d, t, u, v;
-	register int i, j;
+	int i, j;
 
 	if (start) {
 		start = 0;

--- a/Source/Terra/pnint.cpp
+++ b/Source/Terra/pnint.cpp
@@ -72,7 +72,7 @@ float noise2(float vec[2])
 {
 	int bx0, bx1, by0, by1, b00, b10, b01, b11;
 	int rx0, rx1, ry0, ry1, *q, sx, sy, a, b, t, u, v;
-	register i, j;
+	i, j;
 
 	if (start) {
 		start = 0;
@@ -115,7 +115,7 @@ float noise3(int vec[3])
 	int bx0, bx1, by0, by1, bz0, bz1, b00, b10, b01, b11;
 	int *q;
 	__int64 rx0, rx1, ry0, ry1, rz0, rz1, sy, sz, a, b, c, d, t, u, v;
-	register int i, j;
+	int i, j;
 
 
 	if (start) {

--- a/Source/Terra/pnt.cpp
+++ b/Source/Terra/pnt.cpp
@@ -25,7 +25,7 @@ float noise3D(float vec[3])
 { 
 	int bx0, bx1, by0, by1, bz0, bz1, b00, b10, b01, b11; 
 	float rx0, rx1, ry0, ry1, rz0, rz1, *q, sx, sy, sz, a, b, c, d, t, u, v; 
-	register int i, j; 
+	int i, j;
 
 	setup(0, bx0,bx1, rx0,rx1); 
 	setup(1, by0,by1, ry0,ry1); 

--- a/Source/Terra/tgai.cpp
+++ b/Source/Terra/tgai.cpp
@@ -8,7 +8,7 @@ void TGAHEAD::save3layers(const char* fname,int sizeX,int sizeY,unsigned char* R
 	Height=(short)sizeY;
 	ff.write(this,sizeof(TGAHEAD));
 	unsigned char *line = new unsigned char[sizeX*3],*p;
-	register unsigned int i,j;
+	unsigned int i,j;
 	for(j = 0; j<sizeY; j++){
 		p = line;
 		for(i = 0; i<sizeX; i++){
@@ -32,7 +32,7 @@ void TGAHEAD::load3layers(const char* fname,int sizeX,int sizeY,unsigned char* R
 	ff.read(this,sizeof(TGAHEAD));
 	if( (Width!=sizeX) || (Height!=sizeY) ) return;
 	unsigned char *line = new unsigned char[sizeX*3],*p;
-	register unsigned int i,j;
+	unsigned int i,j;
 /*	for(j = 0; j<sizeY; j++){
 		p = line;
 		ff.read(line,sizeX*3);
@@ -83,7 +83,7 @@ bool TGAHEAD::load2buf(unsigned char* buf)
 	else return 0;
 
 	unsigned char *line = new unsigned char[Width*byteInPixel],*p;
-	register unsigned int i,j,k;
+	unsigned int i,j,k;
 	int ibeg,jbeg,iend,jend,ik,jk;
 	if(ImageDescriptor&0x20) { jbeg=0; jend=Height; jk=1;}
 	else { jbeg=Height-1; jend=-1; jk=-1;}
@@ -109,7 +109,7 @@ void TGAHEAD::load2RGBL(int sizeX,int sizeY, unsigned long* RGBLBuf)
 {
 	if( (Width!=sizeX) || (Height!=sizeY) ) return;
 	unsigned char *line = new unsigned char[sizeX*3],*p;
-	register unsigned int i,j;
+	unsigned int i,j;
 	int ibeg,jbeg,iend,jend,ik,jk;
 	if(ImageDescriptor&0x20) { jbeg=0; jend=sizeY; jk=1;}
 	else { jbeg=sizeY-1; jend=-1; jk=-1;}

--- a/Source/Terra/tools.cpp
+++ b/Source/Terra/tools.cpp
@@ -51,7 +51,7 @@ void BitMap::place(char* name,int x,int y,int _force,int _mode,int _border,int _
 
 	//	vMap -> increase(y,y + sy - 1);
 
-		register int i,j;
+		int i,j;
 		int v,xx,yy,vv;
 		for(j = 0;j < sy;j++){
 			yy = vMap.YCYCL(y + j);
@@ -103,7 +103,7 @@ void BitMap::place(char* name,int x,int y,int _force,int _mode,int _border,int _
 		int xt,yt;
 		int xpp=0,ypp=0;
 
-		register int i,j;
+		int i,j;
 		int v,xx,yy,vv;
 		for(j = 0;j < sy;j++){
 			xt=xbeg; yt=ybeg;
@@ -292,7 +292,7 @@ void S3Danalyze(int S3Dmode, int S3Dlevel, int S3DnoiseLevel, int S3DnoiseAmp, i
 
 	vMap.UndoDispatcher_PutPreChangedArea(x,y,x + xysize,y + xysize);
 
-	register int i,j;
+	int i,j;
 	for(j = 0;j < xysize;j++){
 		p = surface + (j << shape_shift);
 		yy = vMap.YCYCL(y + j);

--- a/Source/Terra/tools.h
+++ b/Source/Terra/tools.h
@@ -269,7 +269,7 @@ public:
 		//void vrtMap::deltaZone(int x,int y,int rad,int smth,int dh,int smode,int eql)
 		int eql=0;
 
-		register int i,j;
+		int i,j;
 		int max;
 		int* xx,*yy;
 

--- a/Source/Terra/worldGen.cpp
+++ b/Source/Terra/worldGen.cpp
@@ -113,7 +113,7 @@ void RestrictMinMax(int& v)
 void vrtMap::r_net_init(void)
 {
 //	if(Verbose) cout << "RoughNetInit..."<<endl;
-	register unsigned int x,y;
+	unsigned int x,y;
 
 	for(x = 0;x < GEONET_POWER; x++) r_preRNDVAL[x] = XRnd(0xFFFFFFFF);
 	for(y = 0;y < PART_MAX;y++)
@@ -150,7 +150,7 @@ void vrtMap::r_net_init(void)
 void vrtMap::m_net_init(void)
 {
 //	if(Verbose) cout << "MapNetInit..."<<endl;
-	register unsigned int x,y;
+	unsigned int x,y;
 
 	for(x = 0;x < GEONET_POWER; x++) m_preRNDVAL[x] = XRnd(0xFFFFFFFF);
 	for(y = 0;y < PART_MAX; y++)
@@ -168,7 +168,7 @@ void vrtMap::m_net_init(void)
 void vrtMap::rough_init(void)
 {
 //	if(Verbose) cout << "RoughInit..."<<endl;
-	register unsigned int x,y,i,j;
+	unsigned int x,y,i,j;
 
 	for(y = 0,j = Stage*(part_map_size_y/QUANT);y <= part_map_size_y + QUANT;y += QUANT,j++){
 		if(j == PART_MAX*(part_map_size_y/QUANT)) j = 0;
@@ -181,7 +181,7 @@ void vrtMap::generate_roughness_map(void)
 {
 	if(MINSQUARE > 1){
 		RNDVAL = r_cycleRNDVAL[Stage][0];
-		register unsigned int i;
+		unsigned int i;
 		unsigned short* pc = color_map;
 		unsigned short* pa = alt_map;
 		for(i = 0;i < part_map_size + H_SIZE;i++){
@@ -288,7 +288,7 @@ void vrtMap::generate_roughness_map(void)
 void vrtMap::map_init(void)
 {
 //	if(Verbose) cout << "MapInit..."<<endl;
-	register unsigned int i,j,x,y;
+	unsigned int i,j,x,y;
 
 	for(y = 0,j = Stage*(part_map_size_y/QUANT);y <= part_map_size_y + QUANT;y += QUANT,j++){
 		if(j == PART_MAX*(part_map_size_y/QUANT)) j = 0;
@@ -535,7 +535,7 @@ void vrtMap::worldRelease(void)
 void vrtMap::generate_noise(void)
 {
 	unsigned short* pa = alt_map;
-	register int i,j;
+	int i,j;
 	for(i = 0;i < (int)part_map_size_y;i++)
 		for(j = 0;j < H_SIZE;j++,pa++)
 			*pa += XRnd(NOISE_AMPL);
@@ -557,7 +557,7 @@ void vrtMap::head_vmpWrite(XStream& fmap)
 void vrtMap::partWrite(XStream& ff,int mode, int Stage)
 {
 	vrtMap::sVmpHeader VmpHeader;
-	register int i,j;
+	int i,j;
 	unsigned short* pa = alt_map;
 	unsigned short* pf = surf_map;
 	unsigned char * pw;
@@ -765,7 +765,7 @@ void vrtMap::GeoRecalc(int n, int level, int delta)
 	SetPP(n);
 
 
-	register int i,j;
+	int i,j;
 	int y1m = (y1 + 1) & clip_mask_y;
 	//Если дельта не равна 0 
 	if(r_delta!=0){
@@ -912,7 +912,7 @@ void CUTVMP(void)
 	vMap -> openMirror();
 	int y = vMap.YCYCL(Y0 - v_size/2);
 
-	register int i,j,x;
+	int i,j,x;
 	unsigned char* pa,*pf,*p;
 	unsigned char** lt = vMap -> lineT;
 	for(j = 0;j < v_size;j++,y = vMap.YCYCL(y + 1)){


### PR DESCRIPTION
This removes "register" keyword which causes issues on modern compilers, shouldn't have any secondary effect.