### PR TITLE
Fix MSVC 2019 build

### DIFF
--- a/MSDXSDK_02_06/Include/DXGIType.h
+++ b/MSDXSDK_02_06/Include/DXGIType.h
@@ -14,6 +14,10 @@
 */
 //@@MIDL_FILE_HEADING(  )
 
+
+#include "../shared/dxgi.h"
+#include "../shared/dxgitype.h"
+
 #pragma warning( disable: 4049 )  /* more than 64k source lines */
 
 
@@ -83,6 +87,8 @@ extern "C"{
 #define DXGI_USAGE_SHARED    ( 1L << (3 + 4) )
 #define DXGI_USAGE_PRIMARY    ( 1L << (4 + 4) )
 typedef UINT DXGI_USAGE;
+
+#ifndef DXGI_FORMAT_DEFINED
 
 typedef 
 enum DXGI_FORMAT
@@ -177,6 +183,8 @@ enum DXGI_FORMAT
 	DXGI_FORMAT_B8G8R8X8_UNORM	= 88,
 	DXGI_FORMAT_FORCE_UINT	= 0xffffffffUL
     } 	DXGI_FORMAT;
+
+#endif
 
 typedef struct DXGI_RGB
     {

--- a/MSDXSDK_02_06/Include/rpcsal.h
+++ b/MSDXSDK_02_06/Include/rpcsal.h
@@ -135,6 +135,9 @@
 
 #pragma once
 
+// the file from old DirectX SDK conflists with new Windows SDK
+#if defined(_MSC_VER) && (_MSC_VER < 1900)
+
 #include <specstrings.h>
 
 #ifndef __RPCSAL_H_VERSION__
@@ -384,3 +387,6 @@ extern "C" {
 }
 #endif
 
+#else
+    #include <../shared/rpcsal.h>
+#endif

--- a/MSDXSDK_02_06/Include/rpcsal.h
+++ b/MSDXSDK_02_06/Include/rpcsal.h
@@ -136,7 +136,7 @@
 #pragma once
 
 // the file from old DirectX SDK conflists with new Windows SDK
-#if defined(_MSC_VER) && (_MSC_VER < 1900)
+#if !defined(_MSC_VER) || defined(_MSC_VER) && (_MSC_VER < 1900)
 
 #include <specstrings.h>
 

--- a/Source/Game/Player.cpp
+++ b/Source/Game/Player.cpp
@@ -1526,9 +1526,9 @@ void terVoiceDispatcher::quant()
 			startVoice(it->voiceSetup(),true);
 	}
 
-	voiceQueue_.remove_if(mem_fun_ref(&VoiceTimer::end));
-	delayedVoices_.remove_if(mem_fun_ref(&VoiceTimer::end));
-	disabledVoices_.remove_if(mem_fun_ref(&VoiceTimer::end));
+	voiceQueue_.remove_if(std::mem_fn(&VoiceTimer::end));
+	delayedVoices_.remove_if(std::mem_fn(&VoiceTimer::end));
+	disabledVoices_.remove_if(std::mem_fn(&VoiceTimer::end));
 
 	while(!isVoicePlaying() && !voiceQueue_.empty()){
 		play(voiceQueue_.begin()->voiceSetup());

--- a/Source/Game/StdAfx.h
+++ b/Source/Game/StdAfx.h
@@ -27,7 +27,8 @@
 #include <dplay8.h>
 
 // STL
-#include <vector> 
+#include <random>
+#include <vector>
 #include <list>
 #if defined(_MSC_VER) && (_MSC_VER < 1900)
 // non-standard header

--- a/Source/PluginMAX/zip_headers.h
+++ b/Source/PluginMAX/zip_headers.h
@@ -2,7 +2,6 @@
 #ifndef __ZIP_HEADERS_H__
 #define __ZIP_HEADERS_H__
 
-typedef unsigned char byte;
 typedef long longint;
 typedef unsigned short word;
 

--- a/Source/Render/client/WinVideo.cpp
+++ b/Source/Render/client/WinVideo.cpp
@@ -1,5 +1,7 @@
-#include "StdAfxRD.h"
+// do not define "namespace std" before <amstream.h> include, otherwise compile error: 'byte': ambiguous symbol
 #include <amstream.h>	// DirectShow multimedia stream interfaces
+
+#include "StdAfxRD.h"
 #include <control.h>
 #include <uuids.h>
 #include <assert.h>

--- a/Source/Render/inc/Umath.h
+++ b/Source/Render/inc/Umath.h
@@ -452,7 +452,7 @@ inline float FastInvSqrt(float x)
     union {
         float f;
         uint32_t i;
-    } conv  = { .f = x };
+    } conv  = { x };
     conv.i  = 0x5f3759df - ( conv.i >> 1 );
     conv.f  *= threehalfs - ( x2 * conv.f * conv.f );
     return conv.f;

--- a/Source/Render/src/TileMap.h
+++ b/Source/Render/src/TileMap.h
@@ -8,7 +8,7 @@ const int TILEMAP_SHL  = 6;
 const int TILEMAP_SIZE = 1<<TILEMAP_SHL;
 const int TILEMAP_LOD=5;
 
-//TILEMAP_LOD â ñîîòâåòñòâèè ñ íèì íóæíî èñïðàâèòü ATTRTILE_DRAWLODxxx
+//TILEMAP_LOD Ð² ÑÐ¾Ð¾Ñ‚Ð²ÐµÑ‚ÑÑ‚Ð²Ð¸Ð¸ Ñ Ð½Ð¸Ð¼ Ð½ÑƒÐ¶Ð½Ð¾ Ð¸ÑÐ¿Ñ€Ð°Ð²Ð¸Ñ‚ÑŒ ATTRTILE_DRAWLODxxx
 enum eAttributeTile
 {
 	ATTRTILE_DRAWLOD		=   1<<0,
@@ -47,8 +47,8 @@ class cTileMap : public cUnkObj
 	friend class cScene;
 
 	sTile*			Tile;
-	Vect2i			TileSize;		// ðàçìåð îäíîãî òàéëà
-	Vect2i			TileNumber;		// ÷èñëî òàéëîâ ïî îñÿì
+	Vect2i			TileSize;		// Ñ€Ð°Ð·Ð¼ÐµÑ€ Ð¾Ð´Ð½Ð¾Ð³Ð¾ Ñ‚Ð°Ð¹Ð»Ð°
+	Vect2i			TileNumber;		// Ñ‡Ð¸ÑÐ»Ð¾ Ñ‚Ð°Ð¹Ð»Ð¾Ð² Ð¿Ð¾ Ð¾ÑÑÐ¼
 
 	Vect3d			tilesize;
 
@@ -82,13 +82,13 @@ public:
 
 	cTileMap(cScene* pScene,TerraInterface* terra);
 	virtual ~cTileMap();
-	// îáùèå èíòåðôåéñíûå ôóíêöèè óíàñëåäîâàíû îò cUnkObj
+	// Ð¾Ð±Ñ‰Ð¸Ðµ Ð¸Ð½Ñ‚ÐµÑ€Ñ„ÐµÐ¹ÑÐ½Ñ‹Ðµ Ñ„ÑƒÐ½ÐºÑ†Ð¸Ð¸ ÑƒÐ½Ð°ÑÐ»ÐµÐ´Ð¾Ð²Ð°Ð½Ñ‹ Ð¾Ñ‚ cUnkObj
 	virtual void PreDraw(cCamera *UCamera);
 	virtual void Draw(cCamera *UCamera);
 	virtual void UpdateMap(const Vect2i& pos1, const Vect2i& pos2);
 	void UpdateMap(const Vect2i& pos, float radius) { UpdateMap(pos - Vect2i(radius, radius), pos + Vect2i(radius, radius)); }
 	void Animate(float dt);
-	// îáùèå èíòåðôåéñíûå ôóíêöèè cTileMap
+	// Ð¾Ð±Ñ‰Ð¸Ðµ Ð¸Ð½Ñ‚ÐµÑ€Ñ„ÐµÐ¹ÑÐ½Ñ‹Ðµ Ñ„ÑƒÐ½ÐºÑ†Ð¸Ð¸ cTileMap
 	const Vect2i& GetTileSize()const					{ return TileSize; }
 	const Vect2i& GetTileNumber()const					{ return TileNumber; }
 	sTile& GetTile(int i,int j)							{ return Tile[i+j*GetTileNumber().x]; }

--- a/Source/Render/src/TileMap.h
+++ b/Source/Render/src/TileMap.h
@@ -156,7 +156,7 @@ protected:
 	int CheckLightMapType();
 
 	void BuildRegionPoint();
-#ifdef _WIN32
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
 	friend void cTileMapBorderCall(void* data, Vect2f& p);
 #endif
 

--- a/Source/Render/src/TileMap.h
+++ b/Source/Render/src/TileMap.h
@@ -8,7 +8,7 @@ const int TILEMAP_SHL  = 6;
 const int TILEMAP_SIZE = 1<<TILEMAP_SHL;
 const int TILEMAP_LOD=5;
 
-//TILEMAP_LOD Ð² ÑÐ¾Ð¾Ñ‚Ð²ÐµÑ‚ÑÑ‚Ð²Ð¸Ð¸ Ñ Ð½Ð¸Ð¼ Ð½ÑƒÐ¶Ð½Ð¾ Ð¸ÑÐ¿Ñ€Ð°Ð²Ð¸Ñ‚ÑŒ ATTRTILE_DRAWLODxxx
+//TILEMAP_LOD â ñîîòâåòñòâèè ñ íèì íóæíî èñïðàâèòü ATTRTILE_DRAWLODxxx
 enum eAttributeTile
 {
 	ATTRTILE_DRAWLOD		=   1<<0,
@@ -47,8 +47,8 @@ class cTileMap : public cUnkObj
 	friend class cScene;
 
 	sTile*			Tile;
-	Vect2i			TileSize;		// Ñ€Ð°Ð·Ð¼ÐµÑ€ Ð¾Ð´Ð½Ð¾Ð³Ð¾ Ñ‚Ð°Ð¹Ð»Ð°
-	Vect2i			TileNumber;		// Ñ‡Ð¸ÑÐ»Ð¾ Ñ‚Ð°Ð¹Ð»Ð¾Ð² Ð¿Ð¾ Ð¾ÑÑÐ¼
+	Vect2i			TileSize;		// ðàçìåð îäíîãî òàéëà
+	Vect2i			TileNumber;		// ÷èñëî òàéëîâ ïî îñÿì
 
 	Vect3d			tilesize;
 
@@ -82,13 +82,13 @@ public:
 
 	cTileMap(cScene* pScene,TerraInterface* terra);
 	virtual ~cTileMap();
-	// Ð¾Ð±Ñ‰Ð¸Ðµ Ð¸Ð½Ñ‚ÐµÑ€Ñ„ÐµÐ¹ÑÐ½Ñ‹Ðµ Ñ„ÑƒÐ½ÐºÑ†Ð¸Ð¸ ÑƒÐ½Ð°ÑÐ»ÐµÐ´Ð¾Ð²Ð°Ð½Ñ‹ Ð¾Ñ‚ cUnkObj
+	// îáùèå èíòåðôåéñíûå ôóíêöèè óíàñëåäîâàíû îò cUnkObj
 	virtual void PreDraw(cCamera *UCamera);
 	virtual void Draw(cCamera *UCamera);
 	virtual void UpdateMap(const Vect2i& pos1, const Vect2i& pos2);
 	void UpdateMap(const Vect2i& pos, float radius) { UpdateMap(pos - Vect2i(radius, radius), pos + Vect2i(radius, radius)); }
 	void Animate(float dt);
-	// Ð¾Ð±Ñ‰Ð¸Ðµ Ð¸Ð½Ñ‚ÐµÑ€Ñ„ÐµÐ¹ÑÐ½Ñ‹Ðµ Ñ„ÑƒÐ½ÐºÑ†Ð¸Ð¸ cTileMap
+	// îáùèå èíòåðôåéñíûå ôóíêöèè cTileMap
 	const Vect2i& GetTileSize()const					{ return TileSize; }
 	const Vect2i& GetTileNumber()const					{ return TileNumber; }
 	sTile& GetTile(int i,int j)							{ return Tile[i+j*GetTileNumber().x]; }
@@ -156,7 +156,9 @@ protected:
 	int CheckLightMapType();
 
 	void BuildRegionPoint();
-	//friend void cTileMapBorderCall(void* data,Vect2f& p);
+#ifdef _WIN32
+	friend void cTileMapBorderCall(void* data, Vect2f& p);
+#endif
 
 	Vect3f To3D(const Vect2f& pos);
 	void DrawLines();

--- a/Source/TriggerEditor/TriggerExport.h
+++ b/Source/TriggerEditor/TriggerExport.h
@@ -52,8 +52,8 @@ class TriggerChain;
 class Trigger;
 
 //-----------------------------
-class Action;
-class Condition;
+struct Action;
+struct Condition;
 
 typedef ShareHandle<Action> ActionPtr;
 typedef ShareHandle<Condition> ConditionPtr;

--- a/Source/Units/FrameField.cpp
+++ b/Source/Units/FrameField.cpp
@@ -15,7 +15,7 @@
 
 bool removeNotAliveMonk(MonkList& unitList)
 {
-    auto i = remove_if(unitList.begin(), unitList.end(), not1(mem_fun(&terUnitMonk::alive)));
+    auto i = remove_if(unitList.begin(), unitList.end(), not_fn(&terUnitMonk::alive));
     if(i != unitList.end()){
         unitList.erase(i, unitList.end());
         return true;

--- a/Source/Util/MissionDescription.cpp
+++ b/Source/Util/MissionDescription.cpp
@@ -574,6 +574,5 @@ void MissionDescription::setSinglePlayerDifficulty(Difficulty difficutyIn)
 
 void MissionDescription::shufflePlayers()
 {
-	srand(timeGetTime());
-	random_shuffle(&playersShufflingIndices[0], &playersShufflingIndices[0] + playerAmountScenarioMax);
+	shuffle(&playersShufflingIndices[0], &playersShufflingIndices[0] + playerAmountScenarioMax, std::default_random_engine(timeGetTime()));
 }

--- a/Source/XTool/XResource/zip_headers.h
+++ b/Source/XTool/XResource/zip_headers.h
@@ -2,7 +2,6 @@
 #ifndef __ZIP_HEADERS_H__
 #define __ZIP_HEADERS_H__
 
-typedef unsigned char byte;
 typedef long longint;
 typedef unsigned short word;
 

--- a/Source/tx3d/SimpleTurbulator3D.cpp
+++ b/Source/tx3d/SimpleTurbulator3D.cpp
@@ -13,7 +13,7 @@
 
 using namespace tx3d;
 
-auto_ptr<SimpleTurbulator3D> SimpleTurbulator3D::sharedInstance;
+std::unique_ptr<SimpleTurbulator3D> SimpleTurbulator3D::sharedInstance;
 
 float SimpleTurbulator3D::turbulate3D(const Vector3D &v, float persistence, int octaveCount, Interpolator3D *interpolator) {
 	float sum = 0.0;

--- a/Source/tx3d/SimpleTurbulator3D.hpp
+++ b/Source/tx3d/SimpleTurbulator3D.hpp
@@ -31,7 +31,7 @@ namespace tx3d {
 			}
 
 		protected:
-			static std::auto_ptr<SimpleTurbulator3D> sharedInstance;
+			static std::unique_ptr<SimpleTurbulator3D> sharedInstance;
 			Vector3D freqV;
 	};
 


### PR DESCRIPTION
Fix MSVC 2019 compilation with C++17 mode
- replace `auto_ptr` with `unique_ptr`
- replace deprecated in C++17 `not1, mem_fun, mem_fun_ref` with `non_fn, mem_fn`
- replace deprecated `random_shuffle` with `shuffle` and `std::default_random_engine(timeGetTime())`
- fix struct / class warning when use forwad declarations
- fix compilation when include `<amstream.h>` after `using namespace std`
- fix DX includes, thx to @SSE4 