### PR TITLE
Tweaks and boost stacktrace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,11 @@ set(CMAKE_CXX_EXTENSIONS ON)
 # options
 OPTION(FINAL_VERSION "Generate Final version" On)
 OPTION(OPTION_STATIC_BUILD "Generate static build" On)
+OPTION(OPTION_DISABLE_STACKTRACE "Disable stacktrace support" Off)
 OPTION(GEN_SCRIPTS "Re-Generates game scripts" OFF)
 
 # depends
-FIND_PACKAGE(Boost REQUIRED)
+FIND_PACKAGE(Boost REQUIRED) # Boost stacktrace was introduced in 1.65 but is bugged
 FIND_PACKAGE(VORBIS)
 
 # globals
@@ -87,6 +88,9 @@ ENDIF()
 IF(CMAKE_BUILD_TYPE MATCHES Debug)
     ADD_DEFINITIONS(-DPERIMETER_DEBUG)
     MESSAGE("Compiling Debug version")
+ENDIF()
+IF(OPTION_DISABLE_STACKTRACE)
+    ADD_DEFINITIONS(-DOPTION_DISABLE_STACKTRACE)
 ENDIF()
 
 IF( CMAKE_HOST_WIN32 OR MINGW )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,10 +7,7 @@ PROJECT(perimeter)
 # modules
 SET(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
-#SET(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
-IF(MINGW)
-    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".dll")
-ENDIF()
+SET(CMAKE_CONFIGURATION_TYPES "Release;Debug;MinSizeRel;RelWithDebInfo")
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -18,6 +15,7 @@ set(CMAKE_CXX_EXTENSIONS ON)
 
 # options
 OPTION(FINAL_VERSION "Generate Final version" On)
+OPTION(OPTION_STATIC_BUILD "Generate static build" On)
 OPTION(GEN_SCRIPTS "Re-Generates game scripts" OFF)
 
 # depends
@@ -29,11 +27,16 @@ INCLUDE_DIRECTORIES(SYSTEM
         ${Boost_INCLUDE_DIRS}
 )
 
-# optional vorbis
 
 IF(MSVC)
     #MSVC compiler specifics
 ELSE()
+    IF(OPTION_STATIC_BUILD)
+        SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+        SET(BUILD_SHARED_LIBS OFF)
+        SET(CMAKE_EXE_LINKER_FLAGS "-static")
+    ENDIF()
+    
     #Others
     INCLUDE(CheckCXXCompilerFlag)
     SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-Werror=delete-non-virtual-dtor -Wno-conversion-null")
@@ -80,6 +83,10 @@ IF(FINAL_VERSION)
     ADD_DEFINITIONS(-D_FINAL_VERSION_)
 ELSE()
     MESSAGE("Not compiling Final version")
+ENDIF()
+IF(CMAKE_BUILD_TYPE MATCHES Debug)
+    ADD_DEFINITIONS(-DPERIMETER_DEBUG)
+    MESSAGE("Compiling Debug version")
 ENDIF()
 
 IF( CMAKE_HOST_WIN32 OR MINGW )

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -98,6 +98,11 @@ IF(PERIMETER_WINDOWS)
             vfw32
             strmiids
     )
+ELSE()
+    SET(perimeter_LINK_LIBS ${perimeter_LINK_LIBS}
+            # dl is required for dladdr in stacktrace,
+            dl
+    )
 ENDIF()
 
 SET(perimeter_SRCS

--- a/Source/Game/Player.cpp
+++ b/Source/Game/Player.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "Umath.h"
@@ -640,7 +638,7 @@ terUnitBase* terPlayer::createUnit(const UnitTemplate& data)
 
 void terPlayer::incomingCommandRegion(const netCommand4G_Region& reg)
 {
-	//Region Buffer можно сделать глобальным
+	//Region Buffer РјРѕР¶РЅРѕ СЃРґРµР»Р°С‚СЊ РіР»РѕР±Р°Р»СЊРЅС‹Рј
 	XBuffer RegionBuffer(5000, 1);
 	RegionBuffer.init();
 	RegionBuffer.write(reg.pData_, reg.dataSize_);
@@ -1031,7 +1029,7 @@ void terPlayer::universalSave(SavePlayerData& data, bool userSave)
 				xassert(data.buildings.back());
 			}
 			else 
-				xassert_s(0 && "Игнорируется запись здания: ", (*bi)->attr().internalName());
+				xassert_s(0 && "РРіРЅРѕСЂРёСЂСѓРµС‚СЃСЏ Р·Р°РїРёСЃСЊ Р·РґР°РЅРёСЏ: ", (*bi)->attr().internalName());
 		}
 	}
 	
@@ -1336,7 +1334,7 @@ void terPlayer::rebuildDefenceMapQuant()
 terUnitBase* terPlayer::findPathToTarget(DefenceMap& defenceMap, terUnitAttributeID id, terUnitBase* ignoreUnit, const Vect2f& nearPosition, Vect2iVect& path)
 {
 	MTL();
-	xassert(id != UNIT_ATTRIBUTE_ANY && "Недопустим любой юнит для цели атаки");
+	xassert(id != UNIT_ATTRIBUTE_ANY && "РќРµРґРѕРїСѓСЃС‚РёРј Р»СЋР±РѕР№ СЋРЅРёС‚ РґР»СЏ С†РµР»Рё Р°С‚Р°РєРё");
 	UnitList targets;
 	UnitList::iterator ui;
 	FOR_EACH(Units, ui)

--- a/Source/Game/Runtime.cpp
+++ b/Source/Game/Runtime.cpp
@@ -188,11 +188,12 @@ void HTManager::init()
 
 	static XBuffer errorHeading;
 	errorHeading.SetRadix(16);
-	errorHeading < currentVersion <
+	errorHeading < currentVersion
 #ifdef _FINAL_VERSION_
-		" Final"
-#else
-		" Release"
+		< " Final"
+#endif
+#ifdef PERIMETER_DEBUG
+        < " DBG"
 #endif
 		< " OS: " <= GetVersion();
 
@@ -570,7 +571,7 @@ void checkSingleRunning()
 //------------------------------
 int PASCAL WinMain(HINSTANCE hInst, HINSTANCE hPrev, LPSTR szCmdLine, int sw)
 {
-#ifdef _FINAL_VERSION_
+#if defined(_FINAL_VERSION_) && !defined(PERIMETER_DEBUG)
 	checkSingleRunning();
 #endif
 

--- a/Source/Game/Runtime.cpp
+++ b/Source/Game/Runtime.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "Umath.h"
@@ -44,7 +42,7 @@ const char* currentVersion =
 
 #ifdef _SINGLE_DEMO_
 const char* currentShortVersion = 
-"Комтек'04 демо, v"
+"РљРѕРјС‚РµРє'04 РґРµРјРѕ, v"
 #include "../version.h"
 ;
 #endif

--- a/Source/Game/Universe.cpp
+++ b/Source/Game/Universe.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "ForceField.h"
@@ -88,7 +86,7 @@ void UpdateRegionMap(int x1,int y1,int x2,int y2)
 }
 
 terUniverse::terUniverse(PNetCenter* net_client, MissionDescription& mission, SavePrm& data, PROGRESSCALLBACK loadProgressUpdate) :
-	terHyperSpace(net_client, mission), //mission может измениться в случае rePlay-а
+	terHyperSpace(net_client, mission), //mission РјРѕР¶РµС‚ РёР·РјРµРЅРёС‚СЊСЃСЏ РІ СЃР»СѓС‡Р°Рµ rePlay-Р°
 	UnitGrid(vMap.H_SIZE, vMap.V_SIZE),
 	cluster_column_(vMap.V_SIZE)
 {
@@ -135,7 +133,7 @@ terUniverse::terUniverse(PNetCenter* net_client, MissionDescription& mission, Sa
 	//UniversalLoad
 
 	//---------------------
-	global_time.setTime(mission.globalTime); // Нужно установить время до загрузки spg
+	global_time.setTime(mission.globalTime); // РќСѓР¶РЅРѕ СѓСЃС‚Р°РЅРѕРІРёС‚СЊ РІСЂРµРјСЏ РґРѕ Р·Р°РіСЂСѓР·РєРё spg
 
 	//---------------------
 	data = SavePrm();
@@ -162,7 +160,7 @@ terUniverse::terUniverse(PNetCenter* net_client, MissionDescription& mission, Sa
 	//---------------------
 	gameShell->changeControlState(manualData.controls);
 	
-	// Загрузка игроков
+	// Р—Р°РіСЂСѓР·РєР° РёРіСЂРѕРєРѕРІ
 	xassert(manualData.players.size() <= NETWORK_PLAYERS_MAX);
 	vector<int> playerLoadIndices;
 	for(int i = 0; i < manualData.players.size(); i++){
@@ -725,13 +723,13 @@ MissionDescription::MissionDescription(const char* fname, GameType gameType)
 		}
 
 		worldID_ = vMap.getWorldID(worldName);
-		xassert_s(worldID() != -1 && "Не найден мир в worlds.prm: ", worldName);
+		xassert_s(worldID() != -1 && "РќРµ РЅР°Р№РґРµРЅ РјРёСЂ РІ worlds.prm: ", worldName);
 
 		missionDescriptionStr_ = qdTextDB::instance().getText(missionDescriptionID);
 		if(missionDescriptionStr_ == "")
 			missionDescriptionStr_ = missionDescriptionID;
 
-		// Установка АИ
+		// РЈСЃС‚Р°РЅРѕРІРєР° РђР
 		for(int i = 0; i < min(NETWORK_PLAYERS_MAX, playerAmountScenarioMax); i++){
 			playersData[i].clan = i;
 			switch(gameType_){
@@ -1244,7 +1242,7 @@ void terUniverse::clearLinkAndDelete()
 	PlayerVect::iterator pi;
 	FOR_EACH(Players, pi)
 		(*pi)->DestroyLink();
-	select.Quant();//Потом перенести в graph
+	select.Quant();//РџРѕС‚РѕРј РїРµСЂРµРЅРµСЃС‚Рё РІ graph
 	FOR_EACH(Players, pi)
 		(*pi)->DeleteQuant();
 	monks.deleteQuant();

--- a/Source/UserInterface/BattleMenu.cpp
+++ b/Source/UserInterface/BattleMenu.cpp
@@ -267,9 +267,9 @@ void onMMBattleFrmButton(CShellWindow* pWnd, InterfaceEventCode code, int param)
 		CComboWindow *pCombo = (CComboWindow*) pWnd;
 		pCombo->Array.push_back( getItemTextFromBase("Exodus").c_str() );
 		pCombo->Array.push_back( getItemTextFromBase("Empire").c_str() );
-//		#ifndef _DEMO_
-//			pCombo->Array.push_back( getItemTextFromBase("Harkback").c_str() );
-//		#endif
+#if !defined(_DEMO_) && !defined(_PERIMETER_ADDON_)
+        pCombo->Array.push_back( getItemTextFromBase("Harkback").c_str() );
+#endif
 		pCombo->size = pCombo->Array.size();
 		pCombo->pos = 0;
 	}

--- a/Source/UserInterface/GameShell.cpp
+++ b/Source/UserInterface/GameShell.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "PrmEdit.h"
@@ -276,7 +274,7 @@ windowClientSize_(1024, 768)
 			_bCursorVisible = 0;
 //			_shellIconManager.GetWnd(SQSH_MM_SPLASH1)->Show(1);
 //			_shellIconManager.SetModalWnd(SQSH_MM_SPLASH1);
-			_shellIconManager.AddDynamicHandler(showReels, CBCODE_QUANT); //ждать пока не слетится
+			_shellIconManager.AddDynamicHandler(showReels, CBCODE_QUANT); //Р¶РґР°С‚СЊ РїРѕРєР° РЅРµ СЃР»РµС‚РёС‚СЃСЏ
 		} else {
 			startWithScreen(SQSH_MM_START_SCR);
 		}
@@ -1157,7 +1155,7 @@ bool GameShell::DebugKeyPressed(sKey& Key)
 			size_t pos = saveName.rfind("RESOURCE\\");
 			if(pos != string::npos)
 				saveName.erase(0, pos);
-			//Несколько кривой участок кода, не будет работать с HT
+			//РќРµСЃРєРѕР»СЊРєРѕ РєСЂРёРІРѕР№ СѓС‡Р°СЃС‚РѕРє РєРѕРґР°, РЅРµ Р±СѓРґРµС‚ СЂР°Р±РѕС‚Р°С‚СЊ СЃ HT
 			HTManager::instance()->GameClose();
 			HTManager::instance()->GameStart(MissionDescription(saveName.c_str()));
 		}
@@ -1572,7 +1570,7 @@ void GameShell::ControlUnpressed(int key)
 				if(_shellIconManager.IsInterface())
 					_shellCursorManager.ShowCursor();
 				
-				//восстановить положение курсора
+				//РІРѕСЃСЃС‚Р°РЅРѕРІРёС‚СЊ РїРѕР»РѕР¶РµРЅРёРµ РєСѓСЂСЃРѕСЂР°
 				//Vect2f v;
 				//ConvertWorldToScreen(_MapMoveStartPoint, v);
 				//SetCursorPos(v.x, v.y);
@@ -1930,14 +1928,14 @@ void GameShell::CameraQuant()
 {
 	if(!cameraMouseTrack && cameraCursorInWindow && !_bMenuMode && 
 		!cameraMouseShift && !cameraMouseZoom && !isScriptReelEnabled()){
-		//сдвиг когда курсор у края окна
+		//СЃРґРІРёРі РєРѕРіРґР° РєСѓСЂСЃРѕСЂ Сѓ РєСЂР°СЏ РѕРєРЅР°
 		//if(!CursorOverInterface)
 		terCamera->mouseQuant(mousePosition());
 	}
 	
 	MousePositionLock = 0;
 	
-	//поворот вслед за мышью
+	//РїРѕРІРѕСЂРѕС‚ РІСЃР»РµРґ Р·Р° РјС‹С€СЊСЋ
 	if(cameraMouseTrack && MouseMoveFlag){
 		terCamera->tilt(mousePositionDelta());
 		
@@ -1945,7 +1943,7 @@ void GameShell::CameraQuant()
 		setCursorPosition(Vect2f::ZERO);
 	}
 	
-	//смещение вслед за мышью
+	//СЃРјРµС‰РµРЅРёРµ РІСЃР»РµРґ Р·Р° РјС‹С€СЊСЋ
 	if(cameraMouseShift && MouseMoveFlag){
 		terCamera->shift(mousePositionDelta());
 		setCursorPosition(mapMoveStartPoint());
@@ -2024,7 +2022,7 @@ void CShellLogicDispatcher::init()
 	
 	initFonts();
 
-	//камера и сцена для моделей в окошке
+	//РєР°РјРµСЂР° Рё СЃС†РµРЅР° РґР»СЏ РјРѕРґРµР»РµР№ РІ РѕРєРѕС€РєРµ
 	m_hScene = terVisGeneric->CreateScene();
 
 	m_hLight = m_hScene->CreateLight(ATTRLIGHT_DIRECTION);
@@ -2035,7 +2033,7 @@ void CShellLogicDispatcher::init()
 	m_hLight->SetDirection(Vect3f(0,0,-1));
 
 	m_hCamera = m_hScene->CreateCamera();
-	m_hCamera->SetAttr(ATTRCAMERA_PERSPECTIVE); // перспектива
+	m_hCamera->SetAttr(ATTRCAMERA_PERSPECTIVE); // РїРµСЂСЃРїРµРєС‚РёРІР°
 
 	MatXf CameraMatrix;
 	Identity(CameraMatrix);
@@ -2060,11 +2058,11 @@ void CShellLogicDispatcher::init()
                       _small_camera_rect_dx, _small_camera_rect_dy);
     Vect2f focus(1.0f, 1.0f);
     Vect2f zplane(30.0f, 10000.0f);
-    m_hCamera->SetFrustum(                          // устанавливается пирамида видимости
-            &center,								// центр камеры
-            &clip,									// видимая область камеры
-            &focus,									// фокус камеры
-            &zplane									// ближайший и дальний z-плоскости отсечения
+    m_hCamera->SetFrustum(                          // СѓСЃС‚Р°РЅР°РІР»РёРІР°РµС‚СЃСЏ РїРёСЂР°РјРёРґР° РІРёРґРёРјРѕСЃС‚Рё
+            &center,								// С†РµРЅС‚СЂ РєР°РјРµСЂС‹
+            &clip,									// РІРёРґРёРјР°СЏ РѕР±Р»Р°СЃС‚СЊ РєР°РјРµСЂС‹
+            &focus,									// С„РѕРєСѓСЃ РєР°РјРµСЂС‹
+            &zplane									// Р±Р»РёР¶Р°Р№С€РёР№ Рё РґР°Р»СЊРЅРёР№ z-РїР»РѕСЃРєРѕСЃС‚Рё РѕС‚СЃРµС‡РµРЅРёСЏ
     );
 
 	m_hCamera->SetAttr(ATTRCAMERA_CLEARZBUFFER);
@@ -2502,15 +2500,15 @@ void GameShell::editParameters()
 	bool reloadParameters = false;
 	savePrm().manualData.zeroLayerHeight = vMap.hZeroPlast;
     
-	const char* header = "Заголовок миссии";
-	const char* mission = "Миссия";
-	const char* missionAll = "Миссия все данные";
+	const char* header = "Р—Р°РіРѕР»РѕРІРѕРє РјРёСЃСЃРёРё";
+	const char* mission = "РњРёСЃСЃРёСЏ";
+	const char* missionAll = "РњРёСЃСЃРёСЏ РІСЃРµ РґР°РЅРЅС‹Рµ";
 	const char* debugPrm = "Debug.prm";
-	const char* global = "Глобальные параметры";
-	const char* attribute = "Атрибуты";
-	const char* sounds = "Звуки";
-	const char* interface_ = "Интерфейс";
-	const char* physics = "Физические параметры";
+	const char* global = "Р“Р»РѕР±Р°Р»СЊРЅС‹Рµ РїР°СЂР°РјРµС‚СЂС‹";
+	const char* attribute = "РђС‚СЂРёР±СѓС‚С‹";
+	const char* sounds = "Р—РІСѓРєРё";
+	const char* interface_ = "РРЅС‚РµСЂС„РµР№СЃ";
+	const char* physics = "Р¤РёР·РёС‡РµСЃРєРёРµ РїР°СЂР°РјРµС‚СЂС‹";
 	const char* separator = "--------------";
 
 	vector<const char*> items;

--- a/Source/UserInterface/GameShell.cpp
+++ b/Source/UserInterface/GameShell.cpp
@@ -1058,9 +1058,9 @@ bool GameShell::DebugKeyPressed(sKey& Key)
 		terRenderDevice->Flush(hWndVisGeneric);
 		ShowCursor(1);
 		//setUseAlternativeNames(true);
-		static TriggerEditor triggetEditor(triggerInterface());
+		static TriggerEditor triggerEditor(triggerInterface());
 		TriggerChain* triggerChain = universe()->activePlayer()->getStrategyToEdit();
-		if(triggerChain && triggetEditor.run(*triggerChain, hWndVisGeneric)){
+		if(triggerChain && triggerEditor.run(*triggerChain, hWndVisGeneric)){
 			triggerChain->initializeTriggersAndLinks();
 			triggerChain->save();
 			triggerChain->buildLinks();
@@ -1074,7 +1074,8 @@ bool GameShell::DebugKeyPressed(sKey& Key)
 		terCamera->setFocus(HardwareCameraFocus);
 		ShowCursor(0);				
 		RestoreFocus();									
-		break; }
+		break;
+	}
 #endif
 
 	case VK_F4 | KBD_CTRL:
@@ -1295,7 +1296,7 @@ void GameShell::KeyPressed(sKey& Key)
 	if(missionEditor_ && missionEditor_->keyPressed(Key))
 		return;
 
-#ifndef _FINAL_VERSION_
+#ifdef PERIMETER_DEBUG
 	if (Key.fullkey == (VK_F1|KBD_SHIFT|KBD_CTRL)) {
 		EnableDebugKeyHandlersInitial = EnableDebugKeyHandlers ^= 1;
 		return;

--- a/Source/UserInterface/Installer.cpp
+++ b/Source/UserInterface/Installer.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "Umath.h"
@@ -394,7 +392,7 @@ bool terBuildingInstaller::checkScriptInstructions()
 			const SaveBuildingInstallerInstruction& instruction = *ii;
 			terUnitBase* unit = universe()->findUnitByLabel(instruction.label);
 			if(!unit){
-				xassert_s(0 && "Îáúåêò ïî ìåòêå íå íàéäåí: ", instruction.label);
+				xassert_s(0 && "ÐžÐ±ÑŠÐµÐºÑ‚ Ð¿Ð¾ Ð¼ÐµÑ‚ÐºÐµ Ð½Ðµ Ð½Ð°Ð¹Ð´ÐµÐ½: ", instruction.label);
 			}												
 			else{
 				if(((unit->activity() && instruction.labeledObjectActivity) || (!unit->activity() && !instruction.labeledObjectActivity)) &&

--- a/Source/UserInterface/InterfaceScript.cpp
+++ b/Source/UserInterface/InterfaceScript.cpp
@@ -1,6 +1,3 @@
-// TODO: change encoding to utf-8
-
-
 #include "StdAfx.h"
 
 #include "InterfaceScript.h"

--- a/Source/UserInterface/LanMenu.cpp
+++ b/Source/UserInterface/LanMenu.cpp
@@ -450,16 +450,12 @@ void setFrm(CComboWindow* combo, int number) {
 				break;
 			case BELLIGERENT_HARKBACKHOOD0:
 			case BELLIGERENT_HARKBACKHOOD1:
-				combo->pos = 0;
-				gameShell->getNetClient()->changePlayerBelligerent(number, BELLIGERENT_EXODUS0);
-/*
-				#ifndef _DEMO_
+				#if defined(_DEMO_) || defined(_PERIMETER_ADDON_)
 					combo->pos = 2;
 				#else
 					combo->pos = 0;
 					gameShell->getNetClient()->changePlayerBelligerent(number, BELLIGERENT_EXODUS0);
 				#endif
-*/
 				break;
 			case BELLIGERENT_EMPIRE0:
 			case BELLIGERENT_EMPIRE1:
@@ -494,13 +490,11 @@ void setupFrm(CComboWindow* combo, int number, bool direction) {
 		case 1:
 			curBelligerent = BELLIGERENT_EMPIRE0;
 			break;
-/*
 #ifndef _DEMO_
 		case 2:
 			curBelligerent = BELLIGERENT_HARKBACKHOOD0;
 			break;
 #endif
-*/
 	}
 	gameShell->getNetClient()->changePlayerBelligerent(number, curBelligerent);
 }

--- a/Source/UserInterface/MissionEdit.cpp
+++ b/Source/UserInterface/MissionEdit.cpp
@@ -1,5 +1,3 @@
-// TODO: change encoding to utf-8
-
 #include "StdAfx.h"
 
 #include "MissionEdit.h"
@@ -33,7 +31,7 @@ MissionEditor::MissionEditor()
 MissionEditor::~MissionEditor()
 {
 	if(hardnessChanged_ && 
-		MessageBox(0, "Редактирование неразрушаемости незаписано. Записать?", "Mission editor", MB_YESNO | MB_ICONQUESTION) 
+		MessageBox(0, "Р РµРґР°РєС‚РёСЂРѕРІР°РЅРёРµ РЅРµСЂР°Р·СЂСѓС€Р°РµРјРѕСЃС‚Рё РЅРµР·Р°РїРёСЃР°РЅРѕ. Р—Р°РїРёСЃР°С‚СЊ?", "Mission editor", MB_YESNO | MB_ICONQUESTION) 
 			== IDYES)
 				vMap.saveHardness();
 }
@@ -135,17 +133,17 @@ bool MissionEditor::keyPressed(const sKey& Key)
 		
 	case VK_DELETE:
 		if(editingHardness_){
-			if(MessageBox(0, "Стереть всю неразрушаемость?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES)
+			if(MessageBox(0, "РЎС‚РµСЂРµС‚СЊ РІСЃСЋ РЅРµСЂР°Р·СЂСѓС€Р°РµРјРѕСЃС‚СЊ?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES)
 				clearHardness();
 		}
-		else if(universe()->selectedObject() && ::MessageBox(0, "Удалить выделенный объект?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES){
+		else if(universe()->selectedObject() && ::MessageBox(0, "РЈРґР°Р»РёС‚СЊ РІС‹РґРµР»РµРЅРЅС‹Р№ РѕР±СЉРµРєС‚?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES){
 			universe()->DeleteSelectedObjects();
 			_pUnitHover = 0;
 		}
 		return true;
 
 	case 'D':
-		if(universe()->selectedObject() && ::MessageBox(0, "Удалить выделенный объект?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES){
+		if(universe()->selectedObject() && ::MessageBox(0, "РЈРґР°Р»РёС‚СЊ РІС‹РґРµР»РµРЅРЅС‹Р№ РѕР±СЉРµРєС‚?", "Mission editor", MB_YESNO | MB_ICONQUESTION) == IDYES){
 			universe()->DeleteSelectedObjects();
 			_pUnitHover = 0;
 		}
@@ -258,30 +256,30 @@ terFilthSpotID SelectFilth()
 		terFilthSpotID id;
 	} name[]=
 	{
-		{"дракон",FILTH_SPOT_ID_DRAGON},
-		{"муравей",FILTH_SPOT_ID_ANTS},
-		{"пчела",FILTH_SPOT_ID_WASP},
-		{"приведение",FILTH_SPOT_ID_GHOST},
-		{"глаз",FILTH_SPOT_ID_EYE},
-		{"ворона",FILTH_SPOT_ID_CROW},
-		{"демон",FILTH_SPOT_ID_DAEMON},
-		{"крыса",FILTH_SPOT_ID_RAT},
-		{"червь",FILTH_SPOT_ID_WORM},
-		{"рыба",FILTH_SPOT_ID_SHARK},
-		{"вулкан",FILTH_SPOT_ID_VOLCANO},
-		{"муравей2",FILTH_SPOT_ID_ANTS2},
-		{"змеи",FILTH_SPOT_ID_SNAKE},
-		{"дракон2",FILTH_SPOT_ID_DRAGON2},
-		{"Вулкан от скамдизраптора",FILTH_SPOT_ID_VOLCANO_SCUM_DISRUPTOR},
-		{"Новые муравьи",FILTH_SPOT_ID_A_ANTS}, //Муравьи aant.M3D
-		{"Новые вороны",FILTH_SPOT_ID_A_CROW}, //Вороны abird.M3D
-		{"Новые демоны",FILTH_SPOT_ID_A_DAEMON}, //Демоны ad_DAEMON.M3D
-		{"Новый дракон",FILTH_SPOT_ID_A_DRAGON}, //Дракон adragon_body.M3D adragon_head.M3D adragon_tail.M3D
-		{"Новые глаза",FILTH_SPOT_ID_A_EYE},  //Глаза aeye.M3D
-		{"Новые крысы",FILTH_SPOT_ID_A_RAT}, //Крысы arat.M3D
-		{"Новые пауки",FILTH_SPOT_ID_A_SPIDER}, //Муравьи2 aspider.M3D aspider1.M3D
-		{"Новые осы",FILTH_SPOT_ID_A_WASP}, //Осы awasp.M3D
-		{"Новый червь",FILTH_SPOT_ID_A_WORM},// Червь aworm.M3D
+		{"РґСЂР°РєРѕРЅ",FILTH_SPOT_ID_DRAGON},
+		{"РјСѓСЂР°РІРµР№",FILTH_SPOT_ID_ANTS},
+		{"РїС‡РµР»Р°",FILTH_SPOT_ID_WASP},
+		{"РїСЂРёРІРµРґРµРЅРёРµ",FILTH_SPOT_ID_GHOST},
+		{"РіР»Р°Р·",FILTH_SPOT_ID_EYE},
+		{"РІРѕСЂРѕРЅР°",FILTH_SPOT_ID_CROW},
+		{"РґРµРјРѕРЅ",FILTH_SPOT_ID_DAEMON},
+		{"РєСЂС‹СЃР°",FILTH_SPOT_ID_RAT},
+		{"С‡РµСЂРІСЊ",FILTH_SPOT_ID_WORM},
+		{"СЂС‹Р±Р°",FILTH_SPOT_ID_SHARK},
+		{"РІСѓР»РєР°РЅ",FILTH_SPOT_ID_VOLCANO},
+		{"РјСѓСЂР°РІРµР№2",FILTH_SPOT_ID_ANTS2},
+		{"Р·РјРµРё",FILTH_SPOT_ID_SNAKE},
+		{"РґСЂР°РєРѕРЅ2",FILTH_SPOT_ID_DRAGON2},
+		{"Р’СѓР»РєР°РЅ РѕС‚ СЃРєР°РјРґРёР·СЂР°РїС‚РѕСЂР°",FILTH_SPOT_ID_VOLCANO_SCUM_DISRUPTOR},
+		{"РќРѕРІС‹Рµ РјСѓСЂР°РІСЊРё",FILTH_SPOT_ID_A_ANTS}, //РњСѓСЂР°РІСЊРё aant.M3D
+		{"РќРѕРІС‹Рµ РІРѕСЂРѕРЅС‹",FILTH_SPOT_ID_A_CROW}, //Р’РѕСЂРѕРЅС‹ abird.M3D
+		{"РќРѕРІС‹Рµ РґРµРјРѕРЅС‹",FILTH_SPOT_ID_A_DAEMON}, //Р”РµРјРѕРЅС‹ ad_DAEMON.M3D
+		{"РќРѕРІС‹Р№ РґСЂР°РєРѕРЅ",FILTH_SPOT_ID_A_DRAGON}, //Р”СЂР°РєРѕРЅ adragon_body.M3D adragon_head.M3D adragon_tail.M3D
+		{"РќРѕРІС‹Рµ РіР»Р°Р·Р°",FILTH_SPOT_ID_A_EYE},  //Р“Р»Р°Р·Р° aeye.M3D
+		{"РќРѕРІС‹Рµ РєСЂС‹СЃС‹",FILTH_SPOT_ID_A_RAT}, //РљСЂС‹СЃС‹ arat.M3D
+		{"РќРѕРІС‹Рµ РїР°СѓРєРё",FILTH_SPOT_ID_A_SPIDER}, //РњСѓСЂР°РІСЊРё2 aspider.M3D aspider1.M3D
+		{"РќРѕРІС‹Рµ РѕСЃС‹",FILTH_SPOT_ID_A_WASP}, //РћСЃС‹ awasp.M3D
+		{"РќРѕРІС‹Р№ С‡РµСЂРІСЊ",FILTH_SPOT_ID_A_WORM},// Р§РµСЂРІСЊ aworm.M3D
 	};
 	int sz=sizeof(name)/sizeof(name[0]);
 
@@ -309,10 +307,10 @@ terUnitAttributeID SelectGeo()
 		terUnitAttributeID id;
 	} name[]=
 	{
-		{"гора",UNIT_ATTRIBUTE_GEO_INFLUENCE},
-		{"разлом",UNIT_ATTRIBUTE_GEO_BREAK},
-		{"деффект",UNIT_ATTRIBUTE_GEO_FAULT},
-		{"лицо",UNIT_ATTRIBUTE_GEO_HEAD},
+		{"РіРѕСЂР°",UNIT_ATTRIBUTE_GEO_INFLUENCE},
+		{"СЂР°Р·Р»РѕРј",UNIT_ATTRIBUTE_GEO_BREAK},
+		{"РґРµС„С„РµРєС‚",UNIT_ATTRIBUTE_GEO_FAULT},
+		{"Р»РёС†Рѕ",UNIT_ATTRIBUTE_GEO_HEAD},
 	};
 	int sz=sizeof(name)/sizeof(name[0]);
 
@@ -337,11 +335,11 @@ void MissionEditor::createUnit()
 	terUnitAttributeID attributeID = UNIT_ATTRIBUTE_NONE;
 	const char* modelDirectory = 0;
 
-	const char* itemBuildings = "Здания";
-	const char* itemNature = "Деревья";
-	const char* itemFilth = "Скверна";
-	const char* itemSensors = "Сенсора";
-	const char* itemGeoprocess = "Геопроцессы";
+	const char* itemBuildings = "Р—РґР°РЅРёСЏ";
+	const char* itemNature = "Р”РµСЂРµРІСЊСЏ";
+	const char* itemFilth = "РЎРєРІРµСЂРЅР°";
+	const char* itemSensors = "РЎРµРЅСЃРѕСЂР°";
+	const char* itemGeoprocess = "Р“РµРѕРїСЂРѕС†РµСЃСЃС‹";
 	vector<const char*> items;
 	items.push_back(itemBuildings);
 	items.push_back(itemNature);
@@ -374,7 +372,7 @@ void MissionEditor::createUnit()
 	else if(item == itemSensors){
 		setPlayer(-1);
 		items.clear();
-		const char* itemAlphaPotential = "Полюса для Альфы";
+		const char* itemAlphaPotential = "РџРѕР»СЋСЃР° РґР»СЏ РђР»СЊС„С‹";
 		items.push_back(itemAlphaPotential);
 		const char* item = popupMenu(items);
 		if(item == itemAlphaPotential)
@@ -443,38 +441,38 @@ const char* MissionEditor::info()
 	size_t pos = missionName.rfind("RESOURCE\\");
 	if(pos != string::npos)
 		missionName.erase(0, pos);
-	info_ < "Миссия: " < missionName.c_str() < "\n";
+	info_ < "РњРёСЃСЃРёСЏ: " < missionName.c_str() < "\n";
 
 	terPlayer* player = universe()->activePlayer();
 	if(player->isWorld())
-		info_ < "Игрок \"Мир\"\n";
+		info_ < "РРіСЂРѕРє \"РњРёСЂ\"\n";
 	else 
 		switch(player->playerID()){
 		case 0:
-			info_ < "Игрок1 \"Я\"\n";
+			info_ < "РРіСЂРѕРє1 \"РЇ\"\n";
 			break;
 		case 1:
-			info_ < "Игрок2 \"Враг\"\n";
+			info_ < "РРіСЂРѕРє2 \"Р’СЂР°Рі\"\n";
 			break;
 		default:
-			info_ < "Игрок" <= player->playerID() < "\n";
+			info_ < "РРіСЂРѕРє" <= player->playerID() < "\n";
 		}
 
 	terUnitBase* unit = universe()->selectedObject();
 	if(unit){
-		info_ < "Объект: " < unit->attr().internalName() < "\n";
+		info_ < "РћР±СЉРµРєС‚: " < unit->attr().internalName() < "\n";
 		if(unit->GetModelName())
-			info_ < "Модель: " < unit->GetModelName() < "\n";
+			info_ < "РњРѕРґРµР»СЊ: " < unit->GetModelName() < "\n";
 	}
 
 	if(copiedData_)
-		info_ < "Запомнен: " < getEnumDescriptor(UNIT_ATTRIBUTE_NONE).nameAlt(copiedData_->attributeID) < "\n";
+		info_ < "Р—Р°РїРѕРјРЅРµРЅ: " < getEnumDescriptor(UNIT_ATTRIBUTE_NONE).nameAlt(copiedData_->attributeID) < "\n";
 
 	if(editingHardness_)
-		info_ < (!isShiftPressed() ? "Редактирование некопаемых областей\n" : "Редактирование копаемых областей\n");
+		info_ < (!isShiftPressed() ? "Р РµРґР°РєС‚РёСЂРѕРІР°РЅРёРµ РЅРµРєРѕРїР°РµРјС‹С… РѕР±Р»Р°СЃС‚РµР№\n" : "Р РµРґР°РєС‚РёСЂРѕРІР°РЅРёРµ РєРѕРїР°РµРјС‹С… РѕР±Р»Р°СЃС‚РµР№\n");
 
 	if(terCamera->pathSize())
-		info_ < (terCamera->restricted() ? "Camera: " : "Camera (ограничена): ") <= terCamera->pathSize() < "\n";
+		info_ < (terCamera->restricted() ? "Camera: " : "Camera (РѕРіСЂР°РЅРёС‡РµРЅР°): ") <= terCamera->pathSize() < "\n";
 
 	return info_.address();
 }

--- a/Source/UserInterface/PerimeterShellUI.cpp
+++ b/Source/UserInterface/PerimeterShellUI.cpp
@@ -5283,11 +5283,12 @@ void CProgressCollected::draw(int bFocus)
 
 		XBuffer buffer;
 		buffer.SetDigits(1);
-		if(accumulated < 1.0f)
-			buffer <= accumulated;
-		else
-			buffer <= round(accumulated);
-		buffer < " / " <= round(capacity);
+		if(accumulated < 1.0f) {
+            buffer <= accumulated;
+        } else {
+            buffer <= (int)round(accumulated);
+        }
+		buffer < " / " <= (int)round(capacity);
 
 /*
 		float accL = terRenderDevice->GetFontLength((char*)acc.c_str());

--- a/Source/UserInterface/ShellLogDisp.cpp
+++ b/Source/UserInterface/ShellLogDisp.cpp
@@ -258,13 +258,13 @@ void CShellLogicDispatcher::draw()
 		terRenderDevice->SetFont(0);
 	}
 
-#ifndef _FINAL_VERSION_
+#ifdef PERIMETER_DEBUG
 	if (universe() && universe()->activePlayer() && universe()->activePlayer()->isAI()) {
 		terRenderDevice->SetFont( m_hFontUnitsLabel );
 		terRenderDevice->OutText(950,24,universe()->activePlayer()->difficultyPrm().name,sColor4f(1,1,1,1));
 		terRenderDevice->SetFont( NULL );
 	}
-#endif // _FINAL_VERSION_
+#endif // PERIMETER_DEBUG
 
 	if(_shellIconManager.IsInterface())
 	{

--- a/Source/XTool/CMakeLists.txt
+++ b/Source/XTool/CMakeLists.txt
@@ -1,5 +1,6 @@
 INCLUDE_DIRECTORIES(
         BEFORE .
+        ${Boost_INCLUDE_DIRS}
 )
 
 SET(XTool_SRCS

--- a/Source/XTool/XERRHAND/xerrhand.CPP
+++ b/Source/XTool/XERRHAND/xerrhand.CPP
@@ -1,3 +1,5 @@
+#include <string>
+#include <list>
 #include "xglobal.h"
 #include <float.h>
 //#include "BugslayerUtil.h"
@@ -8,6 +10,15 @@ void xtSysFinit(void);
 int xtDispatchMessage(MSG* msg);
 
 //#define _EXCEPTION_CATCH
+
+#ifndef OPTION_DISABLE_STACKTRACE
+#define BOOST_STACKTRACE_GNU_SOURCE_NOT_REQUIRED 1
+#include "boost/stacktrace.hpp"
+#endif
+
+#ifndef _WIN32
+#define APIENTRY
+#endif
 
 char *defprefix 	= "XHANDLER  INFORM";
 
@@ -58,7 +69,37 @@ char* uctoa(unsigned char a)
 	return _ConvertBuffer;
 }
 
-LONG APIENTRY exHandler(EXCEPTION_POINTERS *except_info)
+
+bool getStackTrace(std::list<std::string>& lines) {
+#ifndef OPTION_DISABLE_STACKTRACE
+    //Get current
+    auto st = boost::stacktrace::stacktrace();
+    //Check if failed to load
+    if (st.empty()) {
+        return false;
+    }
+    //Write lines
+    for (size_t i = 0; i < st.size(); ++i) {
+        //Just store the name instead of full name as we don't really care our own name
+        if (i == 0) {
+            lines.push_front(std::string() + __func__ + " <- last call");
+            continue;
+        }
+
+        //Pull the stacktrace info
+        std::string line = boost::stacktrace::detail::to_string(&st.as_vector()[i], 1);
+        std::string::size_type size = line.size();
+        if (10 <= size) {
+            //Remove the start number and end newline
+            line = line.substr(4, size - 5);
+            lines.push_front(line);
+        }
+    }
+#endif
+    return !lines.empty();
+}
+
+long APIENTRY exHandler(EXCEPTION_POINTERS *except_info)
 {
 	_clearfp();
 	_controlfp( _controlfp(0,0) & ~(0), _MCW_EM ); 
@@ -147,16 +188,16 @@ LONG APIENTRY exHandler(EXCEPTION_POINTERS *except_info)
 				strcat(msg, (i & 7) == 7 ? "\r\n" : " "); 
             }
 
-			/* TODO use Boost
-			strcat(msg,"\r\nCall stack:\r\n");
-			int dwOpts = GSTSO_PARAMS | GSTSO_MODULE | GSTSO_SYMBOL | GSTSO_SRCLINE;
-			const char * szBuff = GetFirstStackTraceString ( dwOpts, except_info) ;
-			while( szBuff ) {
-				strcat(msg, szBuff);
-				strcat(msg,"\r\n");
-				szBuff = GetNextStackTraceString ( dwOpts , except_info ) ;
+            std::list<std::string> linesStackTrace;
+            strcat(msg,"\r\nCall stack:\r\n");
+            if (getStackTrace(linesStackTrace)) {
+                for (std::string line : linesStackTrace) {
+                    strcat(msg, line.c_str());
+                    strcat(msg, "\r\n");
+                }
+            } else {
+                strcat(msg,"Not available\r\n");
             }
-			*/
         }
     }
 

--- a/dockcross/cmake-mingw.sh
+++ b/dockcross/cmake-mingw.sh
@@ -12,6 +12,7 @@ ${CROSS_TRIPLE}-cmake \
 -DOGG_LIBRARY="/usr/lib/mxe/usr/${CROSS_TRIPLE}/lib/libogg.a" \
 -DVORBIS_LIBRARY="/usr/lib/mxe/usr/${CROSS_TRIPLE}/lib/libvorbis.a" \
 -DVORBISFILE_LIBRARY="/usr/lib/mxe/usr/${CROSS_TRIPLE}/lib/libvorbisfile.a" \
+-DOPTION_DISABLE_STACKTRACE=On \
 $@
 
 cd build/${CROSS_TRIPLE}

--- a/dockcross/run.sh
+++ b/dockcross/run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+export SSH_DIR=/noexist
 if [ ! -z $CLEAN ]; then
   rm ./dockcross/dockcross-*-perimeter
 fi


### PR DESCRIPTION
- This PR enables use of boost stacktrace during errors for better debugability, can be disabled via CMake option if Boost is too old (1.66+ is recommended) or undesired.
- Now non MSVC builds will be statically linked, if this is undesired it can be disabled via CMake option.
- Also adds some fixes to revert harkback being disabled and energy bar numbers.
- Some cpp files under UI and Game were converted to utf, the only usage of strings are asserts which shouldnt affect game.  