### PR TITLE
Fix compilation warning at HotKey.cpp

### DIFF
--- a/Source/UserInterface/HotKey.cpp
+++ b/Source/UserInterface/HotKey.cpp
@@ -245,9 +245,9 @@ bool HotKeyManager::loadHotKey(std::vector<HotKey>& simpleHotKeys, size_t i, Ini
         key2 = VK_NONE;
     }
     if (key2 == VK_NONE) {
-        simpleHotKeys.emplace_back(i, threshold, key1, key2, custom);
+        simpleHotKeys.emplace_back(static_cast<int>(i), threshold, key1, key2, custom);
     } else {
-        hotKeys.emplace_back(i, threshold, key1, key2, custom);
+        hotKeys.emplace_back(static_cast<int>(i), threshold, key1, key2, custom);
     }
     return true;
 }


### PR DESCRIPTION
Fix MSVC nagging about size_t -> int conversion:

```
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\xmemory(700,103): warning C4267: аргумент: преобразование из "size_t" в "int"; возможна потеря 
данных [C:\Users\gxcre\perimiter\Perimeter\build\Source\UserInterface\UserInterface.vcxproj]
  (компиляция исходного файла "../../../Source/UserInterface/HotKey.cpp")
      C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.41.34120\include\xmemory(700,103):
      контекст создания экземпляра шаблона (сначала самый старый)
          HotKey.cpp(248,23):
          выполняется компиляция ссылки на экземпляр шаблон функции "_Ty &std::vector<_Ty,std::allocator<_Ty>>::emplace_back<size_t&,float&,int&,int&,bool&>(size_t &,float &,int &,int &,bool &
  )"
          with
          [
              _Ty=HotKey
          ]
```